### PR TITLE
Trains too slow past loop

### DIFF
--- a/TRAP.sln
+++ b/TRAP.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TRAP", "TRAP\TRAP.csproj", "{4758D9B8-2930-45E5-B8FD-1B514D052B94}"
 EndProject

--- a/TRAP/Algorithm.cs
+++ b/TRAP/Algorithm.cs
@@ -858,7 +858,7 @@ namespace TRAP
                 throw new ArgumentException(error);
             }
 
-            /* Write the averaged Data to file for inspection. */
+            /* Write the averaged Data to file for inspection. */            
             FileOperations.wrtieAverageData(averageTrains, stats);
             
             return interpolatedTrains;

--- a/TRAP/Form1.cs
+++ b/TRAP/Form1.cs
@@ -33,8 +33,8 @@ namespace TRAP
         public const double secPerMinute = 60;
 
         /* Timer parameters to keep track of execution time. */
-        private int timeCounter;
-        private bool stopTheClock;
+        private int timeCounter = 0;
+        private bool stopTheClock = false;
 
         public TrainPerformance()
         {
@@ -59,7 +59,6 @@ namespace TRAP
             runSouthernHighlands(sender, e);            // Run Time: 01:15:35.47
             runPortKembla(sender, e);                   // Run Time: 00:11:44.02
 #endif
-
 
         }
         
@@ -447,20 +446,20 @@ namespace TRAP
                      */
                 };
 
-            background.RunWorkerCompleted += (backgroundSender, backgroundEvents) =>
-                {
-                    /* When asynchronous execution complete, reset the timer counter ans stop the clock. */
-                    timeCounter = 0;
-                    stopTheClock = true;
+                background.RunWorkerCompleted += (backgroundSender, backgroundEvents) =>
+                    {
+                        /* When asynchronous execution complete, reset the timer counter ans stop the clock. */
+                        timeCounter = 0;
+                        stopTheClock = true;
 
 #if (!TESTING)
-                    tool.messageBox("Program Complete.");
+                        tool.messageBox("Program Complete.");
 #endif
+                    };
 
-                };
+                background.RunWorkerAsync();
 
-            background.RunWorkerAsync();
-            
+
 
         }
         
@@ -2262,6 +2261,9 @@ namespace TRAP
             if (stopTheClock)
             {
                 ((Timer)sender).Stop();
+                /* Reset the static timer properties. */
+                timeCounter = 0;
+                stopTheClock = false;
                 return;
             }
 


### PR DESCRIPTION
Updated to replace average speed with pro-rata speed, when all trains passing a loop outside a TSR, are too slow.